### PR TITLE
driver/rados: treat OMAP EIO as a PathNotFoundError

### DIFF
--- a/registry/storage/driver/rados/rados.go
+++ b/registry/storage/driver/rados/rados.go
@@ -404,7 +404,7 @@ func (d *driver) List(ctx context.Context, dirPath string) ([]string, error) {
 	files, err := d.listDirectoryOid(dirPath)
 
 	if err != nil {
-		return nil, err
+		return nil, storagedriver.PathNotFoundError{Path: dirPath}
 	}
 
 	keys := make([]string, 0, len(files))


### PR DESCRIPTION
Not sure it's the best way here, but I'd love to get a better error than EIO from RADOS, which seems to be used almost everywhere.

cf docker/distribution#1187
