### PR TITLE
driver/swift: treat empty object list as a PathNotFoundError

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -589,7 +589,7 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 		files = append(files, strings.TrimPrefix(strings.TrimSuffix(obj.Name, "/"), d.swiftPath("/")))
 	}
 
-	if err == swift.ContainerNotFound {
+	if err == swift.ContainerNotFound || (len(objects) == 0 && path != "/") {
 		return files, storagedriver.PathNotFoundError{Path: path}
 	}
 	return files, err


### PR DESCRIPTION
This is a quick fix from me. @lebauce Please take a look.

cf #1187
